### PR TITLE
convert content length to be string instead of int

### DIFF
--- a/examples/RSSI_to_ThingSpeak.ino
+++ b/examples/RSSI_to_ThingSpeak.ino
@@ -69,7 +69,7 @@ void loop() {
     client.println("Connection: close");
     client.println("X-THINGSPEAKAPIKEY: " + writeAPIKey);
     client.println("Content-Type: application/x-www-form-urlencoded");
-    client.println("Content-Length: " + body.length());
+    client.println("Content-Length: " + String(body.length()));
     client.println("");
     client.print(body);
 


### PR DESCRIPTION
the "body.length()" returns an int which must be converted to a string for content length. Failure is not reported and returns false length of conent ... causing field not be updated.